### PR TITLE
BP study derived from SRA study

### DIFF
--- a/src/BP.study.xsd
+++ b/src/BP.study.xsd
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:com="SRA.common" xmlns:bp="BP.common">
+  <xs:import schemaLocation="SRA.common.xsd" namespace="SRA.common"/>
+  <xs:import namespace="BP.common" schemaLocation="BP.common.xsd"/>
+  <xs:include schemaLocation="SRA.study.xsd"/>
+
+  <xs:complexType name="BPStudyType">
+    <xs:annotation>
+      <xs:documentation>
+          A Study is a container for a sequencing investigation that may comprise multiple experiments.
+          The Study has an overall goal, but is otherwise minimally defined in the SRA.
+          A Study is composed of a descriptor, zero or more experiments, and zero or more analyses.
+          The submitter may decorate the Study with web links and properties.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="StudyType">
+        <xs:sequence>
+          <xs:element name="DESCRIPTOR" maxOccurs="1" minOccurs="1" nillable="false">
+            <xs:complexType>
+              <xs:all minOccurs="0">
+                <xs:element name="STUDY_TYPE" maxOccurs="1" minOccurs="1">
+                <xs:annotation>
+                  <xs:documentation>The STUDY_TYPE presents a controlled vocabulary for expressing the overall purpose of the study.</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                  <xs:attribute name="existing_study_type" use="required">
+                    <xs:simpleType>
+                      <xs:restriction base="xs:string">
+                        <xs:enumeration value="Whole slide imaging">
+                          <xs:annotation>
+                            <xs:documentation>
+                              Generic whole slide imaging study.
+                            </xs:documentation>
+                          </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="Other">
+                          <xs:annotation>
+                            <xs:documentation>
+                              Study type not listed.
+                            </xs:documentation>
+                          </xs:annotation>
+                        </xs:enumeration>
+                      </xs:restriction>
+                    </xs:simpleType>
+                  </xs:attribute>
+                  <xs:attribute name="new_study_type" use="optional" type="xs:string">
+                    <xs:annotation>
+                      <xs:documentation>
+                    To propose a new term, select Other and enter a new study type.
+                      </xs:documentation>
+                    </xs:annotation>
+                  </xs:attribute>
+                </xs:complexType>
+              </xs:element>
+              </xs:all>
+            </xs:complexType>
+          </xs:element>
+          <xs:element name="STUDY_CODED_ATTRIBUTES" minOccurs="0" maxOccurs="1">
+						<xs:annotation>
+							<xs:documentation>
+                Coded properties and attributes of the study. These can be entered as tag-code value pairs. Submitters may be asked to follow a community established ontology when describing the work.
+              </xs:documentation>
+						</xs:annotation>
+						<xs:complexType>
+						  <xs:sequence maxOccurs="unbounded" minOccurs="1">
+							<xs:element name="STUDY_CODED_ATTRIBUTE" type="bp:CodedAttributeType"/>
+						  </xs:sequence>
+						</xs:complexType>
+					</xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="STUDY_ATTRIBUTE_SETS">
+            <xs:annotation>
+                <xs:documentation>Sets of properties and attributes of a study.</xs:documentation>
+            </xs:annotation>
+            <xs:complexType>
+                <xs:sequence minOccurs="1">
+                    <xs:element name="STUDY_ATTRIBUTE_SET" type="bp:AttributeSetType" maxOccurs="unbounded"/>
+                </xs:sequence>
+            </xs:complexType>
+          </xs:element>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="BPStudySetType">
+    <xs:sequence minOccurs="1" maxOccurs="unbounded">
+      <xs:element name="BP_STUDY" type="BPStudyType"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:element name="BP_STUDY_SET" type="BPStudySetType">
+    <xs:annotation>
+      <xs:documentation>
+      An STUDY_SET is a container for a set of studies and a common namespace.
+    </xs:documentation>
+    </xs:annotation>
+
+  </xs:element>
+
+  <xs:element name="BP_STUDY" type="BPStudyType"/>
+
+</xs:schema>


### PR DESCRIPTION
Simple extension of the SRA study with BP study types and BP attributes (coded and set). Closes #12 and #13