### PR TITLE
Allow a slide to be from multiple blocks

### DIFF
--- a/src/BP.sample.xsd
+++ b/src/BP.sample.xsd
@@ -72,7 +72,7 @@
     <xs:complexContent>
       <xs:extension base="bp:BPObjectType">
         <xs:sequence>
-          <xs:element name="CREATED_FROM" maxOccurs="1" minOccurs="1">
+          <xs:element name="CREATED_FROM" maxOccurs="unbounded" minOccurs="1">
             <xs:annotation>
               <xs:documentation>Identifies the block the slide is created from.</xs:documentation>
             </xs:annotation>


### PR DESCRIPTION
According to the description:

> A physical slide that has been created out of one or more Samples. 

a slide should be able to have multiple references to blocks. The current schema only allows one. This PR removes this limitation.