### PR TITLE
[checksums] Switch type of required checksum

### DIFF
--- a/src/BP.common.xsd
+++ b/src/BP.common.xsd
@@ -120,12 +120,12 @@
                 </xs:restriction>
             </xs:simpleType>
         </xs:attribute>
-        <xs:attribute name="checksum" type="bp:ChecksumString" use="required">
+        <xs:attribute name="checksum" type="bp:ChecksumString" use="optional">
             <xs:annotation>
                 <xs:documentation>The file checksum.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="unencrypted_checksum" type="bp:ChecksumString" use="optional">
+        <xs:attribute name="unencrypted_checksum" type="bp:ChecksumString" use="required">
             <xs:annotation>
                 <xs:documentation>The checksum of the unencrypted file (used in conjunction with the
                     checksum of an encrypted file).</xs:documentation>


### PR DESCRIPTION
To be able to support the new metadata submitter we want to switch what checksum is required and optional.

The reason is that in the future the submitter needs to submit the metadata files first, and if the _encrypted_ checksum is required that means they need to store all encrypted files in some local system before uploading and that's not feasable for larger datasets. But the unencrypted checksum is much more available before upload and then upload can do encryption in line, requiring no extra local storage.